### PR TITLE
feat: add topics to the csv output

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -350,6 +350,7 @@ for repo_name, repo in repos_with_all_vulns.items():
         vulns[vuln_id]['due_in_days'] = due_in_days
         vulns[vuln_id]['in_breach'] = severity != 'LOW' and due_in_days < 0
         vulns[vuln_id]['repo_alerts'].append((repo_alert['dismissedAt'] is not None, repo_name))
+        vulns[vuln_id]['repo_topics'] = "; ".join(repo_topics_names)
 
 # Convert to a flat list
 def cmp_vulns(vuln_a, vuln_b):
@@ -490,6 +491,7 @@ def print_csv(vulnerabilities):
             "deadline",
             "repositories",
             "severity",
+            "github_topics",
         ],
     )
     writer.writeheader()
@@ -505,6 +507,7 @@ def print_csv(vulnerabilities):
                 f'https://github.com/{org_name}/{repo}/security/dependabot/' for repo in non_closed_repos
             ]),
             "severity": vuln['effective_severity'],
+            "github_topics": vuln['repo_topics'],
         })
 
 


### PR DESCRIPTION
Add a column to the csv output for github topics. This should make it a bit easier for the different teams to determine what they own vulnerability wise every week